### PR TITLE
remove line limit in grammar

### DIFF
--- a/grammars/inform.cson
+++ b/grammars/inform.cson
@@ -4,6 +4,7 @@
   'i7x'
 ]
 'name': 'Inform 7'
+'limitLineLength': no
 
 'repository': {
   # Strings. These can contain [substitutions].


### PR DESCRIPTION
inform 7 commonly has very long lines which breaks syntax highlighting. we can fix this by flagging the grammar to use no line limit.

see: https://github.com/atom/atom/issues/1667